### PR TITLE
Update route configurations for ECS

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -19,6 +19,6 @@ router.register(r'ballots', views.BallotsViewSet)
 schema_view = get_swagger_view(title='Hack Oregon 2018 Local Elections APIs')
 
 urlpatterns = [
-    url(r'^schema/', schema_view),
+    url(r'^$', schema_view),
     url(r'^', include(router.urls)),
 ]

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -4,17 +4,17 @@
 if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
 
     # Push only if we're testing the master branch
-    #if [ "$TRAVIS_BRANCH" == "master" ]; then
+    if [ "$TRAVIS_BRANCH" == "master" ]; then
 
         echo Getting the ECR login...
         eval $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
 
         REMOTE_DOCKER_PATH="$DOCKER_REPO"/"$DOCKER_REPO_NAMESPACE"/"$DOCKER_IMAGE"
-        
+
         # tag with branch and travis build number then push
         TAG=travis-buildnum-"$TRAVIS_BUILD_NUMBER"
         echo Tagging with "$TAG"
-        docker tag "$DOCKER_IMAGE":latest "$REMOTE_DOCKER_PATH":"$TAG"    
+        docker tag "$DOCKER_IMAGE":latest "$REMOTE_DOCKER_PATH":"$TAG"
         docker push "$REMOTE_DOCKER_PATH":"$TAG"
 
         # tag with "latest" then push
@@ -22,16 +22,16 @@ if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
         echo Tagging with "$TAG"
         docker tag "$DOCKER_IMAGE":latest "$REMOTE_DOCKER_PATH":"$TAG"
         docker push "$REMOTE_DOCKER_PATH":"$TAG"
-        
+
         #echo Running ecs-deploy.sh script...
         bin/ecs-deploy.sh  \
            --service-name "$ECS_SERVICE_NAME" \
            --cluster "$ECS_CLUSTER"   \
            --image "$REMOTE_DOCKER_PATH":latest \
            --timeout 300
-    #else
-    #    echo "Skipping deploy because branch is not master"
-    #fi
+    else
+       echo "Skipping deploy because branch is not master"
+    fi
 else
     echo "Skipping deploy because it's a pull request"
 fi

--- a/elections_api/settings.py
+++ b/elections_api/settings.py
@@ -167,7 +167,7 @@ STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
-STATIC_URL = '/static/'
+STATIC_URL = '/local-elections/static/'
 
 #custom test runner to toggle between Managed=True and Managed=False for models handling test db
 #TEST_RUNNER = 'api.utils.UnManagedModelTestRunner'

--- a/elections_api/urls.py
+++ b/elections_api/urls.py
@@ -4,5 +4,6 @@ from django.urls import path
 
 
 urlpatterns = [
+    path('local-elections/admin/', admin.site.urls),
     url(r'^local-elections/', include('api.urls')),
 ]


### PR DESCRIPTION
Just a suite of minor changes:

  1. Make swagger the root page
  2. Adjust static files so they look at `/local-elections/static` instead of `/static`
  3. Only deploy when the master branch builds successfully.